### PR TITLE
Add default payment currency to config.php

### DIFF
--- a/app/code/Laybuy/LaybuyPayments/etc/config.xml
+++ b/app/code/Laybuy/LaybuyPayments/etc/config.xml
@@ -27,6 +27,7 @@
                 <sdk_url><![CDATA[https://sandbox-docs.laybuy.com]]></sdk_url>
                 <paymentInfoKeys>result,token,orderId,amount,currency,merchantReference,processed</paymentInfoKeys>
                 <privateInfoKeys>token,processed</privateInfoKeys>
+                <payment_currency>NZD</payment_currency>
             </laybuy_laybuypayments>
         </payment>
     </default>


### PR DESCRIPTION
When I installed the newest extension with multi currency I was getting an error on checkout. I was seeing this in our logs:

```
==> log/magento/payment.log <==
[2018-06-20 11:27:05] main.DEBUG: array (
  'redirect response body' =>
  stdClass::__set_state(array(
     'result' => 'ERROR',
     'error' => 'Specified currency is invalid.',
  )),
) [] []
[2018-06-20 11:27:05] main.DEBUG: array (
  'FAILED TO GET returnURL' =>
  stdClass::__set_state(array(
     'result' => 'ERROR',
     'error' => 'Specified currency is invalid.',
  )),
) [] []
```

This was because I hadn't gone to admin unchecked "use default" on the payment currency config and saved, therefore there was no database config for payment_currency. This change means that if no config is explicitly set in admin it will default to NZD.
